### PR TITLE
G11 Bros, we are so back

### DIFF
--- a/code/modules/research/designs/ammolathe_designs.dm
+++ b/code/modules/research/designs/ammolathe_designs.dm
@@ -752,7 +752,7 @@
 	materials = list(/datum/material/iron = 16000, /datum/material/blackpowder = 2500)
 	build_path = /obj/item/ammo_box/a308box/soviet
 	category = list("initial", "Advanced Ammo")
-/*
+/
 /datum/design/ammolathe/a762
 	name = "7.62 ammo box"
 	id = "a762"
@@ -773,7 +773,7 @@
 	materials = list(/datum/material/iron = 12000, /datum/material/blackpowder = 1000)
 	build_path = /obj/item/ammo_box/m473/rubber
 	category = list("initial", "Advanced Ammo")
-*/
+
 /datum/design/ammolathe/a40mmbuck
 	name = "40mm buckshot ammo box"
 	id = "a40mmbuck"
@@ -781,14 +781,14 @@
 	build_path = /obj/item/ammo_box/a40mm/buck
 	category = list("initial", "Advanced Ammo")
 
-/*
+
 /datum/design/ammolathe/m473incin
 	name = "4.73mm incendiary caseless ammo box"
 	id = "m473incin"
 	materials = list(/datum/material/iron = 20000, /datum/material/blackpowder = 3000)
 	build_path = /obj/item/ammo_box/m473/incendiary
 	category = list("initial", "Advanced Ammo")
-*/
+/
 
 /*
 /datum/design/ammolathe/m473u235
@@ -797,7 +797,7 @@
 	materials = list(/datum/material/titanium = 10000, /datum/material/blackpowder = 2000)
 	build_path = /obj/item/ammo_box/m473/uraniumtipped
 	category = list("initial", "Advanced Ammo")
-
+*/
 
 /datum/design/ammolathe/m473wound
 	name = "4.73mm flat-nose caseless ammo box"
@@ -819,7 +819,7 @@
 	materials = list(/datum/material/iron = 12000, /datum/material/titanium = 15000, /datum/material/blackpowder = 3000)
 	build_path = /obj/item/ammo_box/m473/hv
 	category = list("initial", "Advanced Ammo")
-*/
+/
 
 /datum/design/ammolathe/a357ricochet
 	name = ".357 ricochet ammo"
@@ -832,7 +832,6 @@
 /// Improvised stuff
 //////////
 /// AMMO!
-
 /datum/design/ammolathe/improvised/a22
 	name = ".22lr ammo box"
 	id = "handloader_a22"


### PR DESCRIPTION

## About The Pull Request
<!-- Write here -->
un-commented the 4.73 ammo type to back to the recipe list of the ammo bench. This change is due to the fact that the G11 does indeed still spawn (at least on Parhump) and getting a max tier weapon which you now cannot in any way source ammo for is one of the most depressing things that can happen in this game.
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
fix: un-commented 4.73 ammo types back to the ammo bench. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
